### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/PackageReferenceCleaner/PackageReferenceCleaner.csproj
+++ b/src/PackageReferenceCleaner/PackageReferenceCleaner.csproj
@@ -14,14 +14,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="SponsorLinker.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\readme.md" Link="readme.md" />
+    <None Include="SponsorLinker.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" Version="1.0.1" Pack="false" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.3" />
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="0.10.2" />-->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink